### PR TITLE
Add Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,25 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OpenProse skill
+        run: |
+          git clone --depth 1 https://github.com/openprose/prose.git /tmp/prose
+          mkdir -p ~/.claude/skills
+          cp -r /tmp/prose/skills/open-prose ~/.claude/skills/open-prose
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "prose run pr-review.prose"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 

--- a/pr-review.prose
+++ b/pr-review.prose
@@ -1,0 +1,18 @@
+---
+name: pr-review
+version: 0.1.0
+description: Review a pull request for correctness, style, and potential issues.
+---
+
+# PR Review
+
+Review the current pull request.
+
+## Steps
+
+1. Read the diff of all changed files.
+2. For each changed file, check for:
+   - Correctness: logic errors, off-by-one mistakes, missing error handling at boundaries.
+   - Style: consistency with the existing codebase conventions.
+   - Security: injection risks, leaked secrets, unsafe input handling.
+3. Summarise findings as a PR review comment. If everything looks good, say so briefly.


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs an automated Claude Code review on PR open
- Installs the OpenProse skill via `git clone` and runs `pr-review.prose`
- Includes a placeholder `pr-review.prose` that reviews for correctness, style, and security

## Test plan
- [ ] Verify this PR itself triggers the workflow
- [ ] Check that the OpenProse skill installs correctly in CI
- [ ] Confirm Claude posts a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)