### PR TITLE
fix: resolve Windows-style backslash paths in input resolution

### DIFF
--- a/src/press-resolver.ts
+++ b/src/press-resolver.ts
@@ -29,7 +29,8 @@ export interface ResolvedPressCall {
 // ---------------------------------------------------------------------------
 
 /**
- * Determine if a value looks like a resolvable file path (contains `/` and ends with `.md`, excluding URLs).
+ * Determine if a value looks like a resolvable file path (contains a path
+ * separator and ends with `.md`, excluding URLs).
  * @param value - The input string to check.
  * @returns `true` if the value should be read from disk during input resolution.
  */
@@ -37,7 +38,7 @@ export function isResolvablePath(value: string): boolean {
 	if (value.startsWith("http://") || value.startsWith("https://")) {
 		return false;
 	}
-	return value.includes("/") && value.endsWith(".md");
+	return (value.includes("/") || value.includes("\\")) && value.endsWith(".md");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/environment.test.ts
+++ b/test/environment.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { join } from "node:path";
 import { JsEnvironment, SANDBOX_BUILTINS } from "../src/environment.js";
 
 describe("JsEnvironment", () => {
@@ -67,7 +68,7 @@ describe("JsEnvironment", () => {
 	it("require: node built-ins", async () => {
 		const env = new JsEnvironment();
 		const result = await env.exec('const path = require("path"); console.log(path.join("a", "b"))');
-		expect(result.output).toBe("a/b");
+		expect(result.output).toBe(join("a", "b"));
 	});
 
 	it("require: rejects non-builtins", async () => {

--- a/test/press-resolver.test.ts
+++ b/test/press-resolver.test.ts
@@ -38,6 +38,10 @@ describe("isResolvablePath", () => {
 		expect(isResolvablePath("/absolute/path/to/file.md")).toBe(true);
 	});
 
+	it("returns true for a Windows-style absolute path", () => {
+		expect(isResolvablePath("C:\\Users\\me\\docs\\file.md")).toBe(true);
+	});
+
 	it("returns false for a bare word like 'haiku'", () => {
 		expect(isResolvablePath("haiku")).toBe(false);
 	});


### PR DESCRIPTION
## Problem

`isResolvablePath()` only treats a value as a resolvable file path when it contains a forward slash:

```ts
return value.includes("/") && value.endsWith(".md");
```

On Windows, absolute paths and `fs.mkdtempSync`-produced paths use `\` separators (`C:\Users\me\docs\file.md`), so every such input fails the check. `resolveValue()` / `resolveInputs()` then return the literal path string to the model instead of the file's content — silently, since a Windows path looks like a perfectly valid literal.

This breaks 9 existing tests on Windows (`test/press-resolver.test.ts`: 8, `test/rlm.test.ts` "resolves .md file paths to content in system prompt": 1); they all write real temp files and pass absolute native paths through resolution. It also affects real CLI/library usage on Windows: `press run ... --input C:\path\doc.md` passes the path string itself into the program context instead of the document.

Provenance: found by running the test suite on Windows (no matching open issue at the time of writing).

## Fix

Accept both `/` and `\` as path separators in `isResolvablePath()`. All callers (`resolveValue`, `resolveInputs`, and `resolveContextValue` in `system-prompt.ts`) route through this single predicate, so one change fixes context-stack file inlining as well as caller-input resolution. POSIX behavior is unchanged; URLs remain excluded.

Also fixes one platform-naive test assertion that assumed POSIX output from `path.join("a", "b")`, and adds a unit case documenting backslash acceptance.

## Testing

- `npx vitest --run test/press-resolver.test.ts test/environment.test.ts test/rlm.test.ts`
  - Before: `Tests 10 failed | 176 passed (186)` on Windows
  - After: `Tests 117 passed (117)`
- `npm run build` — clean compile.
