### PR TITLE
fix: stop delegation cleanup from leaking unhandled rejections

### DIFF
--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -705,7 +705,8 @@ export async function press(query: string, context: Record<string, unknown> | un
 		})();
 
 		pendingRlmCalls.add(promise);
-		promise.finally(() => pendingRlmCalls.delete(promise));
+		const removeFromPending = () => pendingRlmCalls.delete(promise);
+		promise.then(removeFromPending, removeFromPending);
 
 		return promise;
 	};

--- a/test/rlm.test.ts
+++ b/test/rlm.test.ts
@@ -547,6 +547,33 @@ describe("press", () => {
 		expect(toolResult!.content).toContain("other-component");
 	});
 
+	it("caught delegation failure does not surface as a phantom error", async () => {
+		const events: Array<{ type: string; invocationId?: string; error?: string | null }> = [];
+		const callLLM = mockToolCallLLM([
+			tc(`try { await press("child task", undefined, { model: "failer" }) } catch (e) { console.log("caught:", e.message) }`, "t1"),
+			tc('return "ok"', "t2"),
+		]);
+
+		const result = await press("parent task", undefined, {
+			callLLM,
+			maxDepth: 3,
+			models: {
+				failer: {
+					callLLM: async () => {
+						throw new Error("child boom");
+					},
+				},
+			},
+			observer: { emit: (event) => events.push(event as { type: string; invocationId?: string; error?: string | null }) },
+		});
+
+		expect(result.answer).toBe("ok");
+		const rootIterationEnds = events.filter((e) => e.type === "iteration:end" && e.invocationId === "root");
+		for (const event of rootIterationEnds) {
+			expect(event.error).toBeNull();
+		}
+	});
+
 	it("use + systemPrompt concatenated", async () => {
 		const systemPrompts: string[] = [];
 		const callLLM: CallLLM = async (messages, systemPrompt) => {


### PR DESCRIPTION
## Problem

`pressFn` tracks spawned delegations in `pendingRlmCalls` using:

```ts
promise.finally(() => pendingRlmCalls.delete(promise));
```

`Promise.prototype.finally()` returns a **new** promise that rejects with the same reason when the original rejects. Nothing ever handles that derived promise, so every failed delegation leaks an `unhandledRejection` even when the caller handled the error correctly.

Two concrete consequences:

1. **Phantom errors in the parent loop.** While a parent exec is in flight, the engine registers a temporary `process.on("unhandledRejection")` handler (see `JsEnvironment.exec`) to surface stray async failures to the model. The leaked rejection from the cleanup chain gets captured there, so sandbox code that *correctly* recovers via `try { await press(...) } catch { ... }` still sees the error appended to its iteration output — teaching the model that its error handling failed when it didn't.
2. For unawaited fire-and-forget delegations that reject after the exec window closes, the rejection reaches Node's default handler (process exit on Node ≥ 15).

Provenance: found by code inspection while reading the delegation lifecycle; no matching open issue at the time of writing. Reproduced with a regression test.

## Fix

Attach both fulfillment and rejection handlers so no dangling promise is created; the original promise's handling semantics are unchanged:

```ts
const removeFromPending = () => pendingRlmCalls.delete(promise);
promise.then(removeFromPending, removeFromPending);
```

The `.then(...)` result always fulfills, so nothing rejects unhandled.

## Testing

Added `caught delegation failure does not surface as a phantom error` in `test/rlm.test.ts`: a child whose LLM driver throws is awaited inside a sandbox `try/catch`; asserts the run completes and that root-iteration events carry no error.

- Pre-fix: fails with `expected 'child boom' to be null` (the caught child error leaked into the parent's iteration output).
- Post-fix: passes.
- `npx vitest --run test/rlm.test.ts` — 56/57 pass on Windows; the single failure (`auto-resolve file paths > resolves .md file paths...`) is pre-existing on `main` and is addressed by #17.
- `npm run build` — clean compile.
